### PR TITLE
Melhoria: saúde robusta e reinício automático nos serviços do docker-…

### DIFF
--- a/lab/docker/docker-compose.yml
+++ b/lab/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     command: "/scripts/run-all.sh"
     tty: true
     networks:
-        - hikari
+      - hikari
     volumes:
       - ./scripts:/scripts
     depends_on:
@@ -34,6 +34,7 @@ services:
   kafka:
     container_name: kafka
     image: wurstmeister/kafka:2.13-2.8.1
+    restart: on-failure
     ports:
       - "9092:9092"
     environment:
@@ -52,6 +53,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+      start_period: 60s
     networks:
       - hikari
     logging:
@@ -60,6 +62,7 @@ services:
   elasticsearch:
     container_name: elastic
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+    restart: on-failure
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=true
@@ -76,12 +79,14 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+      start_period: 60s
     logging:
       driver: none
 
   logstash:
     container_name: logstash
     image: docker.elastic.co/logstash/logstash:7.10.2
+    restart: on-failure
     ports:
       - "5000:5000"
     volumes:
@@ -96,12 +101,14 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+      start_period: 60s
     logging:
       driver: none
 
   kibana:
     container_name: kibana
     image: docker.elastic.co/kibana/kibana:7.10.2
+    restart: on-failure
     ports:
       - "5601:5601"
     environment:
@@ -118,6 +125,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+      start_period: 60s
     logging:
       driver: none
 
@@ -125,6 +133,7 @@ services:
     container_name: fastapi
     build:
       context: ../app
+    restart: on-failure
     ports:
       - "8000:8000"
     volumes:
@@ -144,6 +153,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 10
+      start_period: 60s
     logging:
       driver: none
 
@@ -151,4 +161,3 @@ networks:
   hikari:
     name: hikari
     driver: bridge
-


### PR DESCRIPTION
Este PR aprimora a resiliência dos serviços definidos no `docker-compose.yml` do ambiente HIKARI.

### Alterações realizadas:
- Adição de `restart: on-failure` nos serviços principais (Elasticsearch, Kafka, Kibana, Logstash, FastAPI).
- Inclusão do parâmetro `start_period` nos `healthcheck` para tolerar tempo de boot de serviços como Elasticsearch e Kafka.
- Garantia de que todos os containers críticos só iniciam após os serviços dependentes estarem saudáveis.

### Motivação:
Anteriormente, o ambiente podia falhar silenciosamente se algum container demorasse a inicializar ou falhasse na primeira tentativa. Essas mudanças mitigam esse comportamento e aumentam a confiabilidade da orquestração automatizada via `run-all.sh`.
